### PR TITLE
Fixed ldap-auth create-account-option + added some logging

### DIFF
--- a/ldapauth/ldapauth.php
+++ b/ldapauth/ldapauth.php
@@ -52,18 +52,23 @@ function ldapauth_unload() {
 function ldapauth_hook_authenticate($a,&$b) {
 	$mail = '';
 	if(ldapauth_authenticate($b['username'],$b['password'],$mail)) {
-		$results = q("SELECT * FROM account where account_email = '%s' AND account_flags in (0,1) limit 1",
-			dbesc($b['username'])
+		$results = q("SELECT * FROM account where account_email = '%s' OR account_email = '%s'  AND account_flags in (0,1) limit 1",
+			dbesc($b['username']), dbesc($mail)
 		);
-		if((! $results) && ($mail) && get_config('ldapauth','create_account')) {
+		if((! $results) && ($mail) && intval(get_config('ldapauth','create_account')) == 1) {
 			require_once('include/account.php');
 			$acct = create_account(array('email' => $mail, 'password' => random_string()));			
 			if($acct['success']) {
 				logger('ldapauth: Created account for ' . $b['username'] . ' using ' . $mail);
+				note(t('You were recognized as local LDAP-user and an account was created for you.'));
 				$b['user_record'] = $acct['account'];
 				$b['authenticated'] = 1;
 			}
 
+		} elseif(intval(get_config('ldapauth','create_account')) != 1 && (! $results)) {
+                  logger('ldapauth: User '.$b['username'].' authenticated but no db-record and. Rejecting auth.');
+		  notice(t('You were recognized as local LDAP-user but there is no redmatrix-account for you.'));
+		  return;
 		}
 		if($results) {
 			logger('ldapauth: Login success for ' . $b['username']);
@@ -75,8 +80,8 @@ function ldapauth_hook_authenticate($a,&$b) {
 }
 
 
-function ldapauth_authenticate($username,$password,$mail) {
-
+function ldapauth_authenticate($username,$password,&$mail) {
+    logger('ldapauth: Searching user '.$username.'.');
     $ldap_server   = get_config('ldapauth','ldap_server');
     $ldap_binddn   = get_config('ldapauth','ldap_binddn');
     $ldap_bindpw   = get_config('ldapauth','ldap_bindpw');
@@ -84,31 +89,42 @@ function ldapauth_authenticate($username,$password,$mail) {
     $ldap_userattr = get_config('ldapauth','ldap_userattr');
     $ldap_group    = get_config('ldapauth','ldap_group');
 
-    if(! ((strlen($password))
-            && (function_exists('ldap_connect'))
-            && (strlen($ldap_server))))
+    if(empty($password)) {
+        logger('ldapauth: Empty Password not allowed.');
+        return false;
+    }
+
+    if(!function_exists('ldap_connect')
+       || empty($ldap_server)) {
+            logger('ldapauth: PHP-LDAP fail or no server set.');
             return false;
+    }
 
     $connect = @ldap_connect($ldap_server);
 
-    if(! $connect)
+    if(! $connect) {
+	logger('ldapauth: Unable to connect to server');
         return false;
+    }
 
     @ldap_set_option($connect, LDAP_OPT_PROTOCOL_VERSION,3);
     @ldap_set_option($connect, LDAP_OPT_REFERRALS, 0);
     if((@ldap_bind($connect,$ldap_binddn,$ldap_bindpw)) === false) {
+	logger('ldapauth: Unable to bind to server. Check credentials of binddn.');
         return false;
     }
 
     $res = @ldap_search($connect,$ldap_searchdn, $ldap_userattr . '=' . $username, array('mail'));
 
     if(! $res) {
+	logger('ldapauth: User '.$username.' not found.');
         return false;
     }
 
     $id = @ldap_first_entry($connect,$res);
 
     if(! $id) {
+	logger('ldapauth: User '.$username.' found but unable to load data.');
         return false;
     }
 
@@ -126,11 +142,15 @@ function ldapauth_authenticate($username,$password,$mail) {
 
     $dn = @ldap_get_dn($connect,$id);
 
-    if(! @ldap_bind($connect,$dn,$password))
+    if(! @ldap_bind($connect,$dn,$password)) {
+	logger('ldapauth: User '.$username.' provided wrong credentials.');
         return false;
+    }
 
-    if(! strlen($ldap_group))
+    if(empty($ldap_group)) {
+	logger('ldapauth: User '.$username.' authenticated.');
         return true;
+    }
 
     $r = @ldap_compare($connect,$ldap_group,'member',$dn);
     if ($r === -1) {
@@ -139,7 +159,7 @@ function ldapauth_authenticate($username,$password,$mail) {
         @ldap_close($connect);
 
         if ($eno === 32) {
-            logger("ldapauth: access control group Does Not Exist");
+            logger('ldapauth: access control group Does Not Exist');
             return false;
         }
         elseif ($eno === 16) {
@@ -152,9 +172,10 @@ function ldapauth_authenticate($username,$password,$mail) {
         }
     }
     elseif ($r === false) {
+	logger('ldapauth: User '.$username.' is not in the allowed group.');
         @ldap_close($connect);
         return false;
     }
-
-    return true;
+//    logger('ldapauth: User '.$username.' authenticated and in allowed group.');
+  return true;
 }


### PR DESCRIPTION
As I ran into problem while trying to get our ldap-setup running, I found out that the option to create accounts was somehow not recognized. So I fixed this option and added some logging/messages to make diagnosing ldap-failures easier.
